### PR TITLE
Account for tmp-glibc/deploy/images layout

### DIFF
--- a/do_build.sh
+++ b/do_build.sh
@@ -636,7 +636,7 @@ do_oe_copy_licenses()
         rm -rf "$licences"
         mkdir -p "$OUTPUT_DIR/$NAME/raw/licences"
 
-        for i in "$binaries"/*-image-licences.csv ; do
+        for i in "$binaries"/*/*-image-licences.csv ; do
             local target="$(basename "$i" |
                           sed 's/[^-]*-\(.*-\)image-\(licences.csv\)$/\1\2/')"
             cp "$i" "$licences/$target"


### PR DESCRIPTION
MACHINES now have sub-directories for their images files.
do_oe_copy_licences() should comply.
